### PR TITLE
Added custom provider name for notarization

### DIFF
--- a/commons/macos/smf_notarize/README.md
+++ b/commons/macos/smf_notarize/README.md
@@ -1,0 +1,24 @@
+### Notarize MacOS App
+This lane is used to notarize the a macOS app. 
+
+#####Special Parameter: Provider
+The default value which is passed to the notarization tool for `asc_provider` is the current team id.
+If another value should be used, the `notarization_custom_provider` field in the Config.json for the preferred build variant can be set. If this field is not null it will be used as `asc_provider`.
+
+To find the correct `asc_provider` you can run: 
+
+`xcrun altool --username "username" --password "password" --list-providers`
+
+###Example
+
+```
+smf_notarize(
+    should_notarize: <whether or not the app should be notarized>,
+    dmg_path: <path to dmg>,
+    bundle_id: <bundle identifier>,
+    username: <apple id>,
+    asc_provider: <team id>,	                                    # this is used as default if custom_provider is null		
+    custom_provider: <custom provider name read form Config.json>   # optional
+)
+  
+```

--- a/commons/macos/smf_notarize/smf_notarize.rb
+++ b/commons/macos/smf_notarize/smf_notarize.rb
@@ -1,0 +1,23 @@
+private_lane :smf_notarize do |options|
+
+  should_notarize = options[:should_notarize]
+
+  if should_notarize == false || @platform != :macos
+    return
+  end
+
+  dmg_path = options[:dmg_path]
+  bundle_id = options[:bundle_id]
+  username = options[:username]
+  asc_provider = options[:asc_provider]
+  custom_provider  = options[:custom_provider]
+
+
+  notarize(
+    package: dmg_path,
+    bundle_id: bundle_id,
+    username: username,
+    asc_provider: custom_provider.nil? ? asc_provider : custom_provider,
+    print_log: false
+  )
+end

--- a/setup/macos_setup.rb
+++ b/setup/macos_setup.rb
@@ -159,13 +159,14 @@ private_lane :smf_super_create_dmg_and_gatekeeper do |options|
       team_id: build_variant_config[:team_id]
   )
 
-  notarize(
-      package: dmg_path,
-      bundle_id: build_variant_config[:bundle_identifier],
-      username: build_variant_config[:apple_id],
-      asc_provider: build_variant_config[:team_id],
-      print_log: false
-  ) if build_variant_config[:notarize] == true
+  smf_notarize(
+    should_notarize: build_variant_config[:notarize],
+    dmg_path: dmg_path,
+    bundle_id: build_variant_config[:bundle_identifier],
+    username: build_variant_config[:apple_id],
+    asc_provider: build_variant_config[:team_id],
+    custom_provider: build_variant_config[:notarization_custom_provider]
+  )
 
 end
 


### PR DESCRIPTION
Added functionality to use a custom provider name for the notarization if one is specified in the config.json

Ticket:
https://smartmobilefactory.atlassian.net/browse/STRMAC-1773