### PR TITLE
STRMAC-1772: notarization log url in slack massage

### DIFF
--- a/commons/smf_send_message/smf_send_message.rb
+++ b/commons/smf_send_message/smf_send_message.rb
@@ -66,7 +66,7 @@ private_lane :smf_send_message do |options|
       'Build Type' => type,
     }
 
-    payload['Notarization Log'] = 'http://test.notarize.com'#ENV['FL_NOTARIZE_LOG_FILE_URL'] if @platform == :mac and !ENV['FL_NOTARIZE_LOG_FILE_URL'].nil?
+    payload['Notarization Log'] = ENV['FL_NOTARIZE_LOG_FILE_URL'] if @platform == :mac and !ENV['FL_NOTARIZE_LOG_FILE_URL'].nil?
 
     # Send failure messages also to CI to notice them so that we can see if they can be improved
     begin


### PR DESCRIPTION
If the platform is macos and the notarization log url is available it is logged in the slack massage (on success and on error)
It will look like this:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/33418462/72595328-e5233480-3909-11ea-840e-eeb8db622469.png">
