### PR TITLE
SMFIT-984: Adding Xcode Warnings to PR

### DIFF
--- a/commons/smf_danger/Dangerfile
+++ b/commons/smf_danger/Dangerfile
@@ -82,16 +82,19 @@ else
 end
 
 ## XCODE WARNINGS
-xcode_summary.inline_mode = true
-xcode_summary.ignored_files = 'Pods/**'
 
-xcode_summary.ignored_results { |result|
+if File.exist?('build/reports/errors.json')
+  xcode_summary.inline_mode = true
+  xcode_summary.ignored_files = 'Pods/**'
 
-    if result.location.nil?
-        result.message.scan(/.*\.swift.*/).empty?
-    else
-        File.fnmatch('*[^.swift]', result.location.file_path)
-    end
-}
+  xcode_summary.ignored_results { |result|
 
-xcode_summary.report 'build/reports/errors.json'
+      if result.location.nil?
+          result.message.scan(/.*\.swift.*/).empty?
+      else
+          File.fnmatch('*[^.swift]', result.location.file_path)
+      end
+  }
+
+  xcode_summary.report 'build/reports/errors.json'
+end


### PR DESCRIPTION
Added new plugin [danger-xcode-summary](https://github.com/diogot/danger-xcode_summary) to add xcode warnings to the PRs. This will only show warnings for .swift files. The warnings should also be inline after [this](https://github.com/diogot/danger-xcode_summary/pull/51) is merged.