### PR TITLE
SMFCI-593: Extracting linked issues from ticket data

### DIFF
--- a/commons/smf_git_changelog/smf_git_changelog.rb
+++ b/commons/smf_git_changelog/smf_git_changelog.rb
@@ -145,7 +145,7 @@ def _smf_generate_tickets(changelog)
       tag: ticket_tag,
       link: link,
       title: title,
-      linked_tickets: linked_tickets
+      linked_tickets: linked_tickets.uniq
     }
 
     tickets[:normal].push(new_ticket)


### PR DESCRIPTION
Added functionality to extract linked issues from the ticket data itself. Previously only data from the 'remotelink' api call was taken into account to find linked tickets.