### PR TITLE
Pod push: handle the case where additional_podspecs is nil

### DIFF
--- a/setup/ios_framework_setup.rb
+++ b/setup/ios_framework_setup.rb
@@ -242,7 +242,7 @@ private_lane :smf_super_release_pod do |options|
   podspec_path = build_variant_config[:podspec_path]
   xcode_version = @smf_fastlane_config[:project][:xcode_version]
   specs_repo = build_variant_config[:pods_specs_repo]
-  additional_podspecs = build_variant_config[:additional_podspecs]
+  additional_podspecs = build_variant_config[:additional_podspecs].nil? ? [] : build_variant_config[:additional_podspecs]
   local_branch = options[:local_branch]
 
   smf_git_pull(local_branch)


### PR DESCRIPTION
Issue detected here: https://ci.smfhq.com/job/HiDrive_Framework/job/HiDrive_Sync-Framework_iOS/job/10.3%252Fmaster/43/console

I still need to test that the fix is working