### PR TITLE
Reduce iOS reporting

### DIFF
--- a/commons/reporting/smf_ios_monitor_unit_tests/smf_ios_monitor_unit_tests.rb
+++ b/commons/reporting/smf_ios_monitor_unit_tests/smf_ios_monitor_unit_tests.rb
@@ -25,7 +25,7 @@ private_lane :smf_ios_monitor_unit_tests do |options|
     next
   end
 
-  # Only use one test coverage reports
+  # Only use one test coverage report
   filename = xcresult_file_names.first
   json_result_string = `xcrun xccov view --report --json #{File.join(xcresult_dir, filename)}`
   result_parsed = JSON.parse(json_result_string)
@@ -45,7 +45,7 @@ private_lane :smf_ios_monitor_unit_tests do |options|
 
   # Gather API credentiels and format data for the API
   sheet_id = ENV[$REPORTING_GOOGLE_SHEETS_UNIT_TESTS_DOC_ID_KEY]
-  sheet_name = $REPORTING_GOOGLE_SHEETS_UNIT_TESTS_SHEET_NAME_PLAYGROUND
+  sheet_name = $REPORTING_GOOGLE_SHEETS_UNIT_TESTS_SHEET_NAME
   sheet_data = smf_create_sheet_data_from_entries(sheet_entries, :AUTOMATIC_REPORTING)
 
   # Push to monitoring data to Google Spreadsheet via the API


### PR DESCRIPTION

<img width="928" alt="Screenshot 2021-01-11 at 15 07 37" src="https://user-images.githubusercontent.com/1124776/104192181-c4a79080-541e-11eb-830d-b4bc67a66c4c.png">

remove duplicated reported data on the Google Spreadsheets when a project has multiple target platforms.
Example:
HiDrive-iOS-Sync-Framework being reported twice for the same code coverage