### PR TITLE
Enable fastlane match for mac unit tests

### DIFF
--- a/setup/ios_framework_setup.rb
+++ b/setup/ios_framework_setup.rb
@@ -80,7 +80,7 @@ private_lane :smf_pod_super_unit_tests do |options|
   build_variants_for_pr_check.each { |variant|
 
     build_variant_config = @smf_fastlane_config[:build_variants][variant.to_sym]
-  #  testing_for_mac = build_variant_config[:platform] == 'mac'
+    testing_for_mac = build_variant_config[:platform] == 'mac'
 
     if build_variant_config[:download_provisioning_profiles] != false
 


### PR DESCRIPTION
Allows fixing Settings-Framework unit tests build on VMs