### PR TITLE
Use title as message for slack notification

### DIFF
--- a/commons/smf_send_message/smf_send_slack_message.rb
+++ b/commons/smf_send_message/smf_send_slack_message.rb
@@ -42,6 +42,7 @@ def _smf_slack_message_body(data)
 
   if (text.nil? or text == '')
     pretext = data[:pretext]
+    # Remove emojis for a more minimal message content
     text = pretext.gsub(/:[a-z_]+:/, '').strip()
   end
 


### PR DESCRIPTION
Get rid of the empty slack notification "[no preview available]":

<img width="381" alt="Screenshot 2021-02-19 at 11 42 16" src="https://user-images.githubusercontent.com/1124776/108494222-903db480-72a7-11eb-9242-3045ad9cccc9.png">
