### PR TITLE
Escaping xcode project name

### DIFF
--- a/commons/reporting/smf_meta_report/ios/analysers/smf_get_config_from_xcodeproj.rb
+++ b/commons/reporting/smf_meta_report/ios/analysers/smf_get_config_from_xcodeproj.rb
@@ -20,7 +20,7 @@ def smf_xcodeproj_settings(options={})
     end
   end
 
-  json_string = `xcodebuild -project "#{smf_xcodeproj_file_path}" #{scheme} -showBuildSettings -json`
+  json_string = `xcodebuild -project "#{smf_xcodeproj_file_path}" "#{scheme}" -showBuildSettings -json`
   xcode_settings = JSON.parse(json_string)
   return xcode_settings
 end
@@ -33,7 +33,7 @@ def smf_xcodeproj_targets
 end
 
 def smf_xcodeproj_target_settings(target)
-  json_string = `xcodebuild -project "#{smf_xcodeproj_file_path}" -target #{target} -showBuildSettings -json`
+  json_string = `xcodebuild -project "#{smf_xcodeproj_file_path}" -target "#{target}" -showBuildSettings -json`
   json = JSON.parse(json_string)[0].dig('buildSettings')
 
   return json


### PR DESCRIPTION
Added quotes around the xc project name to prevent projects with whites spaces in their names from failing.