### PR TITLE
SMFIT-1863: Added retry loop for sentry dsym upload

### DIFF
--- a/commons/smf_upload_to_sentry/smf_upload_to_sentry.rb
+++ b/commons/smf_upload_to_sentry/smf_upload_to_sentry.rb
@@ -40,6 +40,14 @@ private_lane :smf_upload_to_sentry do |options|
     success = false
     latest_exception = nil
 
+    # 18.03.2021: Temporary fix added:
+    # This retry loop is a temporary fix for an sentry cli issue
+    # (see https://github.com/getsentry/sentry-fastlane-plugin/issues/38)
+    # which causes the upload to subsequently fail.
+    # This error seems to be some internal error in sentry.
+    # We should keep an eye on it and if it gets fixed
+    # this retry loop should be removed.
+
     while fail_count < MAX_RETRIES && !success
       begin
         sentry_upload_dsym(


### PR DESCRIPTION
After updating the sentry cli, sometimes this error occurs during uploads
![image](https://user-images.githubusercontent.com/33418462/111608209-40380c00-87d9-11eb-90ca-ee0507a2bd2f.png)
and the upload fails. 
This seems to be some sentry internal issue which has been going on for quite a while it seems: https://github.com/getsentry/sentry-fastlane-plugin/issues/38
I added a retry loop around the sentry upload (with a max of 10 retries) which seems to fix the problem for now. This is not the best solution and we should definitely keep an eye on it @kevindelord .