### PR TITLE
HOTFIX: Added check for config.json key 'platform'

### DIFF
--- a/fastlane/utils/config_utils.rb
+++ b/fastlane/utils/config_utils.rb
@@ -21,10 +21,9 @@ end
 
 def smf_is_mac_build(build_variant)
   is_catalyst_mac = smf_is_catalyst_mac_build(build_variant)
-  is_mac = smf_config_get(build_variant.to_sym, :is_mac_app)
   platform = smf_config_get(build_variant.to_sym, :platform)
 
-  is_catalyst_mac || is_mac || platform == 'mac'
+  is_catalyst_mac || platform == 'mac'
 end
 
 # access helper to get the correct config.json entry for a given


### PR DESCRIPTION
This is an ugly quick fix for macos builds. 
## To be discussed:
But we should discuss how we determine whether a build is a macos build.
Currently we check for a config keys:
`is_mac_app`
`platform == 'mac'`

Why? Wouldn't it be enough to check if the `@platform` is macos? Does anyone know why and where we use the `is_mac_app` key? Is it deprecated?