### PR TITLE
Use directly sentry-cli to upload dsym files

### DIFF
--- a/commons/smf_upload_to_sentry/smf_upload_to_sentry.rb
+++ b/commons/smf_upload_to_sentry/smf_upload_to_sentry.rb
@@ -50,16 +50,9 @@ private_lane :smf_upload_to_sentry do |options|
 
     while fail_count < MAX_RETRIES && !success
       begin
-      # 06.12.2021: not using Fastlane because it requires a higher version of the CLI than what we have.
-      # We can try again with Fastlane once our Sentry instance is updated (https://smartmobilefactory.atlassian.net/browse/SMFIT-1967)
-      #   sentry_upload_dsym(
-      #     auth_token: ENV[$SENTRY_AUTH_TOKEN],
-      #     org_slug: org_slug,
-      #     project_slug: project_slug,
-      #     url: 'https://sentry.solutions.smfhq.com/',
-      #     dsym_path: dsym_path
-      # )
-
+        # 06.12.2021: https://smartmobilefactory.atlassian.net/browse/SMFIT-1971
+        # We are not using Fastlane because it requires a higher version of the CLI than what we have.
+        # We can try again with Fastlane once our Sentry instance is updated (https://smartmobilefactory.atlassian.net/browse/SMFIT-1967)
         `sentry-cli --url https://sentry.solutions.smfhq.com/ --auth-token #{ENV[$SENTRY_AUTH_TOKEN]} upload-dsym --org #{org_slug} --project #{project_slug} #{dsym_path}`
         success = true
       rescue => exception


### PR DESCRIPTION
No need to override anything in fastlane in the end, just using the command line

I tested with a test project and the dsym files are there -> https://sentry.solutions.smfhq.com/settings/smf/projects/ios-playground/debug-symbols/ (I cannot add anybody to the team because I don't have permissionw)