### PR TITLE
Feature/smfit 1980

### DIFF
--- a/commons/ios/smf_ios_unit_tests/smf_ios_unit_tests.rb
+++ b/commons/ios/smf_ios_unit_tests/smf_ios_unit_tests.rb
@@ -37,6 +37,7 @@ private_lane :smf_ios_unit_tests do |options|
         disable_concurrent_testing: true,
         reset_simulator: true,
         code_coverage: true,
+        skip_build: true,
         derived_data_path: $IOS_DERIVED_DATA_PATH,
         output_directory: $IOS_BUILD_OUTPUT_DIR,
         output_types: "html,junit,json-compilation-database",


### PR DESCRIPTION
The new version of swiftlint that we use doesn't take into account nested configs if we specify explicitly a config file. 
The easiest and more flexible way is IMO not to give a config file at all, and swiftlint will just read whatever it finds.
-> It's already how it's done locally. 

This inconsistency between local and CI approach was triggering some swiftlint warnings only on the CI in unit tests directories (that have a nested config). This update fixes it.

