### PR TITLE
Handle exception during AppCenter precheck

### DIFF
--- a/commons/smf_upload_to_appcenter/smf_upload_to_appcenter_precheck.rb
+++ b/commons/smf_upload_to_appcenter/smf_upload_to_appcenter_precheck.rb
@@ -10,10 +10,22 @@ private_lane :smf_upload_to_appcenter_precheck do |options|
     destinations: destinations
   )
 
-  smf_upload_to_appcenter_precheck_webhooks(
-    app_name: app_name,
-    owner_name: owner_name
-  )
+  begin
+    smf_upload_to_appcenter_precheck_webhooks(
+      app_name: app_name,
+      owner_name: owner_name
+    )
+  rescue => exception
+    title = "AppCenter webhook precheck failed"
+    message = "The build will still be uploaded to AppCenter. If the issue persist it should be investigated."
+
+    smf_send_message(
+        title: title,
+        message: message,
+        type: "warning",
+        exception: exception
+    )
+  end
 end
 
 private_lane :smf_upload_to_appcenter_precheck_destination_groups do |options|


### PR DESCRIPTION
Deal with the fact that AppCenter is unstable. (see current HiDrive build errors)
It's not a big deal if the pre_check fails, we just post a warning and we'll act on it if there is really an issue. In our case today, it's just a server side problem on AppCenter.

Currently being tested: https://ci.smfhq.com/job/HiDrive_App/job/HiDrive_MacApp_iOS/job/3.2.0%252FSMFIT-1985/3/console

Test result: ✅  Worked (notification was not shown because it's a development branch)