### PR TITLE
Fix DMG script when the app is named the same as what is in the template

### DIFF
--- a/commons/ios/smf_create_dmg_from_app/create_dmg.sh
+++ b/commons/ios/smf_create_dmg_from_app/create_dmg.sh
@@ -120,7 +120,7 @@ if [ "$USE_TEMPLATE" = "true" ]; then
     # Mount bundle - Returns path to Volume (the Volume name can have spaces, dashes, digits and other chars, so the regex covers basically all)
     ORIGINAL_SPARSE_VOLUME_PATH=$(hdiutil attach templateWritable.dmg.sparsebundle | egrep -o '/Volumes/(.*?)+$')
     
-    # We don't want to detach if the name matches because it would make the script fail
+    # We don't want to detach if the path matches because it would make the script fail
     if [ "/Volumes/${VOLNAME}" != $ORIGINAL_SPARSE_VOLUME_PATH ]; then
         # Make sure there is nothing mounted at ${VOLNAME} remaining from previous runs (`|| :` is there to make sure the command can fail without interrupting the script)
         hdiutil detach /Volumes/"${VOLNAME}" || :


### PR DESCRIPTION
DMG generation fails when the app has the same name as the one in the template.
This fixes the issue (tested locally)

PR merged directly to release the app quick 🙈 