### PR TITLE
Implement use_aab flag support for Android builds

### DIFF
--- a/commons/smf_build_app/smf_build_android_app.rb
+++ b/commons/smf_build_app/smf_build_android_app.rb
@@ -5,16 +5,32 @@ private_lane :smf_build_android_app do |options|
 
   letters = build_variant.split('')
   letters[0] = letters[0].upcase if letters.length >= 1
-  build_variant = letters.join('')
+  build_variant_capitalized = letters.join('')
 
-  tasks = ["assemble#{build_variant}"]
+  # Check if use_aab flag is set for this build variant
+  use_aab = smf_config_get(build_variant, :use_aab) || false
+
+  # Determine which tasks to run based on use_aab flag
+  if use_aab
+    # AAB-only mode: only build AAB
+    tasks = ["bundle#{build_variant_capitalized}"]
+    UI.message("AAB-only build mode (use_aab=true) - building bundle only")
+  else
+    # Legacy mode: build both APK and AAB
+    tasks = ["assemble#{build_variant_capitalized}"]
+    UI.message("Legacy build mode (use_aab=false or not set) - building APK and AAB")
+  end
 
   unless keystore_folder.nil?
     keystore_values = smf_pull_keystore(folder: keystore_folder)
 
     if keystore_values[:keystore_file]
 
-      tasks.push("bundle#{build_variant}")
+      # In legacy mode, also build AAB if we have keystore
+      if !use_aab
+        tasks.push("bundle#{build_variant_capitalized}")
+      end
+      
       properties = {
         "android.injected.signing.store.file" => keystore_values[:keystore_file],
         "android.injected.signing.store.password" => keystore_values[:keystore_password],


### PR DESCRIPTION
- Modified find_best_upload_file to respect use_aab flag
- Updated smf_super_upload_to_firebase to only upload AAB when use_aab=true
- Enhanced smf_build_android_app to only build AAB when use_aab=true
- Added proper error handling for missing AAB files when use_aab=true
- Maintains backward compatibility with legacy APK builds

Related to: CBENEFIOS-1699