### PR TITLE
Extended different build paths

### DIFF
--- a/setup/android_setup.rb
+++ b/setup/android_setup.rb
@@ -712,8 +712,12 @@ def extract_package_from_build_gradle
   build_gradle_paths = [
     'app/build.gradle',
     'app/build.gradle.kts',
+    'composeApp/build.gradle.kts',
+    'androidApp/build.gradle.kts',
     './app/build.gradle',
-    './app/build.gradle.kts'
+    './app/build.gradle.kts',
+    './composeApp/build.gradle.kts',
+    './androidApp/build.gradle.kts'
   ]
   
   build_gradle_paths.each do |path|


### PR DESCRIPTION
## Summary
- Added support for additional build.gradle.kts paths in package extraction
- Includes support for Compose Multiplatform projects (composeApp/build.gradle.kts)
- Added support for AndroidApp structure (androidApp/build.gradle.kts)