### PR TITLE
CBENEFIOS-2130: Fix git tag warnings, add platform prefix to build tags

### DIFF
--- a/commons/smf_create_git_tag/smf_create_git_tag.rb
+++ b/commons/smf_create_git_tag/smf_create_git_tag.rb
@@ -2,25 +2,45 @@ private_lane :smf_create_git_tag do |options|
 
   build_variant = options[:build_variant]
   build_number = options[:build_number]
+  platform = options[:platform]
 
-  tag = smf_get_tag_of_app(build_variant, build_number)
+  tag = smf_get_tag_of_app(build_variant, build_number, platform)
 
-  # Check if tag already exists locally (CBENEFIOS-2074)
-  if git_tag_exists(tag: tag)
+  # Check if tag already exists locally
+  UI.message("🔍 Checking local tags for '#{tag}'...")
+  if _smf_git_tag_exists_locally?(tag)
     UI.important("⚠️  Git tag '#{tag}' already exists locally - skipping tag creation")
     UI.important("💡 This can happen if a previous build with the same version already created this tag")
     return tag
   end
+  UI.message("✅ Tag not found locally")
 
   # Check if tag already exists on remote
-  if git_tag_exists(tag: tag, remote: true)
+  UI.message("🔍 Checking remote tags for '#{tag}'...")
+  if _smf_git_tag_exists_on_remote?(tag)
     UI.important("⚠️  Git tag '#{tag}' already exists on remote - skipping tag creation")
     UI.important("💡 This can happen if a previous build with the same version already created this tag")
     return tag
   end
+  UI.message("✅ Tag not found on remote")
 
   add_git_tag(tag: tag)
   UI.success("✅ Created git tag: #{tag}")
 
   tag
+end
+
+# Private: Check if a git tag exists locally (no warnings on missing tag)
+def _smf_git_tag_exists_locally?(tag)
+  result = sh("git tag -l '#{tag}'", log: false).strip
+  !result.empty?
+end
+
+# Private: Check if a git tag exists on remote (no warnings on missing tag)
+def _smf_git_tag_exists_on_remote?(tag)
+  result = sh("git ls-remote --tags origin 'refs/tags/#{tag}'", log: false).strip
+  !result.empty?
+rescue => e
+  UI.important("⚠️  Could not check remote tag (continuing): #{e.message}")
+  false
 end

--- a/commons/smf_version_management/smf_get_next_version_code.rb
+++ b/commons/smf_version_management/smf_get_next_version_code.rb
@@ -20,10 +20,11 @@ def smf_get_next_version_code_from_tags(platform = nil)
     _smf_fetch_build_tags_once
 
     # Query all build tags and extract version codes
-    # Format: build/android/de_alpha/3548 or build/de_alpha/3548
-    # Extract: 3548
+    # New format: build/ios/de_alpha/3548 or build/android/de_alpha/3548
+    # Legacy format: build/de_alpha/3548
+    # Extract: 3548 (last number segment, works for both formats)
     all_version_codes = sh(
-      "git tag -l 'build/*/*' 2>/dev/null | grep -oE '[0-9]+$' | sort -n",
+      "{ git tag -l 'build/*/*/*' 2>/dev/null; git tag -l 'build/*/*' 2>/dev/null; } | grep -oE '[0-9]+$' | sort -n | uniq",
       log: false
     ).strip
 
@@ -97,9 +98,9 @@ def smf_get_current_version_code_from_tags(platform = nil)
     # Fetch build tags (optimized: only once per build, only build/* tags)
     _smf_fetch_build_tags_once
 
-    # Query all build tags and extract version codes
+    # Query all build tags and extract version codes (new + legacy format)
     all_version_codes = sh(
-      "git tag -l 'build/*/*' 2>/dev/null | grep -oE '[0-9]+$' | sort -n",
+      "{ git tag -l 'build/*/*/*' 2>/dev/null; git tag -l 'build/*/*' 2>/dev/null; } | grep -oE '[0-9]+$' | sort -n | uniq",
       log: false
     ).strip
 

--- a/fastlane/utils/utils.rb
+++ b/fastlane/utils/utils.rb
@@ -245,8 +245,12 @@ def smf_get_tag_of_pod(podspec_path)
   "releases/#{version_number}"
 end
 
-def smf_get_tag_of_app(build_variant, build_number)
-  "build/#{build_variant.downcase}/#{build_number}"
+def smf_get_tag_of_app(build_variant, build_number, platform = nil)
+  if platform
+    "build/#{platform.downcase}/#{build_variant.downcase}/#{build_number}"
+  else
+    "build/#{build_variant.downcase}/#{build_number}"
+  end
 end
 
 def smf_get_version_number(build_variant = nil, podspec_path = nil)

--- a/setup/android_setup.rb
+++ b/setup/android_setup.rb
@@ -231,7 +231,11 @@ private_lane :smf_super_pipeline_create_git_tag do |options|
     build_number = smf_get_build_number_of_app
   end
 
-  smf_create_git_tag(build_variant: build_variant, build_number: build_number)
+  smf_create_git_tag(
+    build_variant: build_variant,
+    build_number: build_number,
+    platform: 'android'
+  )
 end
 
 lane :smf_pipeline_create_git_tag do |options|

--- a/setup/apple_setup.rb
+++ b/setup/apple_setup.rb
@@ -281,7 +281,8 @@ private_lane :smf_super_pipeline_create_git_tag do |options|
 
   smf_create_git_tag(
     build_variant: build_variant,
-    build_number: build_number
+    build_number: build_number,
+    platform: 'ios'
   )
 end
 


### PR DESCRIPTION
## Summary

- Replace Fastlane's `git_tag_exists` action with custom methods using `sh(..., log: false)` to eliminate misleading exit code warnings in build logs
- Add explicit log messages distinguishing local vs. remote tag checks
- Add platform prefix to Git tags: `build/ios/de_beta/3878` and `build/android/de_alpha/3549`
- Version code queries updated to support both new (`build/*/*/*`) and legacy (`build/*/*`) formats during transition

## New log output (before/after)

**Before:**
\`\`\`
Shell command exited with exit status 1 instead of 0.
Shell command exited with exit status 2 instead of 0.
\`\`\`

**After:**
\`\`\`
🔍 Checking local tags for 'build/ios/de_beta/3878'...
✅ Tag not found locally
🔍 Checking remote tags for 'build/ios/de_beta/3878'...
✅ Tag not found on remote
✅ Created git tag: build/ios/de_beta/3878
\`\`\`

## Test plan

- [x] iOS build creates tag with format `build/ios/{variant}/{version}`
- [x] Android build creates tag with format `build/android/{variant}/{version}`
- [x] No warning output when tag does not exist (happy path)
- [x] Duplicate tag detection still works (local + remote)
- [x] Version code calculation works with new tag format
- [x] Version code calculation still works with legacy tags (backward compatible)

## Jira

[CBENEFIOS-2130](https://sosimple.atlassian.net/browse/CBENEFIOS-2130)

[CBENEFIOS-2130]: https://sosimple.atlassian.net/browse/CBENEFIOS-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ