### PR TITLE
CBENEFIOS-2507: Bump Firebase release-notes max_length 500 → 1500

### DIFF
--- a/commons/smf_upload_to_firebase/smf_upload_to_firebase.rb
+++ b/commons/smf_upload_to_firebase/smf_upload_to_firebase.rb
@@ -139,12 +139,20 @@ def _smf_get_release_notes_for_firebase(build_variant)
         UI.message("   📋 #{t[:tag]}: #{t[:title]}")
       end
 
-      # Generate AI release notes
+      # Generate AI release notes (CBENEFIOS-2507).
+      # max_length is a HARD character cap that afmcli enforces via a post-truncate
+      # backstop — if the LLM overshoots, the tail is chopped grapheme-cluster-safe.
+      # 500 (the old value) was a regression vs. the original Anthropic flow, which
+      # had max_tokens=500 (~1500-2000 chars output). Real builds confirmed the
+      # truncation cut the "Bug Fixes:" section off mid-word. Firebase App
+      # Distribution accepts up to 16384 chars, so 1500 is conservative AND
+      # leaves room for the full New Features / Improvements / Bug Fixes block
+      # without grapheme drift.
       UI.message("🚀 Calling AI API...")
       ai_notes = smf_generate_ai_release_notes(tickets, {
         build_variant: build_variant,
         language: 'en',
-        max_length: 500,
+        max_length: 1500,
         ticket_commits: ticket_commits
       })
 


### PR DESCRIPTION
Jira: [CBENEFIOS-2507](https://sosimple.atlassian.net/browse/CBENEFIOS-2507) — post-mortem of [CBENEFIOS-2504](https://sosimple.atlassian.net/browse/CBENEFIOS-2504)

## What happened

First production Firebase release-notes mail after the afmcli migration (3.6.0 / 4145 DE, build [#449](https://ci.smfhq.com/job/Corporate-Benefits/job/Corporate-Benefits-MP_Android/job/master/449/)) arrived like this:

```
Release notes for 3.6.0 (4145) DE (4145)
New Features:
- Info-Banner for denied location permissions with settings link.
- Offer tile without icon, address as map link.
- ...
- Fix offer-detail coordinate format mismatch with the web.
Improvements:
- Log missing offerLink and document hidden drag handle on Android.
- Unify location-permission-banner copy across iOS and Android.
Bug F        ← cut off mid-word
```

Build log confirms it: `engine: foundation-models, truncated: true, chars: 500`. The afmcli post-truncate backstop is doing exactly what it was designed to do — keeping the output at the configured hard cap — but the cap was wrong.

## Root cause

`smf_upload_to_firebase.rb:147` passed `max_length: 500` to `smf_generate_ai_release_notes`. The previous Anthropic flow had `max_tokens: 500`, which corresponds to roughly **1500–2000 characters** of output (~3.5 chars/token for English). Translating `500` 1:1 from tokens to characters during the migration was a silent ~3× downgrade.

## Fix

```diff
- max_length: 500,
+ max_length: 1500,
```

Firebase App Distribution accepts up to 16384 chars; 1500 is conservative, fits comfortably in a tester email, and matches the practical output budget of the old Anthropic call. Inline comment now explains the relationship between this caller value and afmcli's truncate semantics for future maintainers.

## Diff

```
commons/smf_upload_to_firebase/smf_upload_to_firebase.rb | 12 ++++++++++--
1 file changed, 10 insertions(+), 2 deletions(-)
```

## Test plan

- [x] Build #449 captured the bug
- [ ] Re-trigger `Corporate-Benefits-MP_Android/master` with `build_variant=de_beta`, `build_node=cibre-studio` after merge
- [ ] Confirm log shows `truncated: false`
- [ ] Confirm the Bug Fixes section is present and complete in the resulting Firebase tester email

## Why this is a hotfix, not a tuning PR

Could also be solved by tightening afmcli's prompt or shrinking the chars/3.5 token budget so the model is forced to stay shorter. Both are valid follow-ups, but neither is necessary today: the caller had clear room to give more space and didn't. Treating this as a single-line config fix is the smallest correct change.

[CBENEFIOS-2507]: https://sosimple.atlassian.net/browse/CBENEFIOS-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2504]: https://sosimple.atlassian.net/browse/CBENEFIOS-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ