### PR TITLE
CBENEFIOS-2508: Aggregated changelog format — ticket-driven primary + commit sub-bullets

### DIFF
--- a/commons/smf_git_changelog/smf_changelog_formatter.rb
+++ b/commons/smf_git_changelog/smf_changelog_formatter.rb
@@ -1,210 +1,257 @@
+# Aggregated changelog formatter (CBENEFIOS-2508).
+#
+# One bullet per ticket id. Each ticket bullet shows the Jira title
+# (which already includes any cross-org APP-XXXX reference). Commits
+# that reference the ticket appear underneath as indented sub-bullets,
+# dropped if they duplicate the title.
+#
+# Commits without a recognised ticket reference are collected at the
+# bottom under "Sonstige Änderungen:" (Q1a in CBENEFIOS-2508 design).
+# Unknown ticket tags (CBENEFIOS-XXXX without Jira data, APP-only refs
+# from sosimple → corporate-benefits, etc.) are dropped entirely (Q2a).
+#
+# Format-aware:
+#   markdown        plain text, NO Jira links (sosimple URLs are unreachable
+#                   for CB-side testers — empirically confirmed in real
+#                   Firebase tester mails after the afmcli migration)
+#   html            full Jira hyperlinks via <a>, nested <ul> for sub-bullets
+#   slack_markdown  Slack <url|text> link form
+#
+# The function signature stays the same so all three callers
+# (smf_git_changelog.rb writing the .txt/.html/.slack files, smf_danger.rb
+# for danger output) keep working.
+
 FORMAT_ELEMENTS = {
   html: {
-    spacer: '<hr>',
-    bullet_point: {
-      prefix: '<li>',
-      postfix: '</li>'
-    },
-    section: {
-      header: {
-        prefix: '<h4>',
-        postfix: '</h4>'
-      },
-      body: {
-        prefix: '<ul>',
-        postfix: '</ul>'
-      }
-    }
-
+    primary_bullet: { prefix: '<li>', postfix: '</li>' },
+    sub_bullet:     { prefix: '<li>', postfix: '</li>' },
+    list_open:      '<ul>',
+    list_close:     '</ul>',
+    section_header: { prefix: '<h4>', postfix: '</h4>' },
+    link_style:     :html,
+    sub_list_break: '<br>'
   },
   markdown: {
-    spacer: "\n\n----",
-    bullet_point: {
-      prefix: '- ',
-      postfix: "\n"
-    },
-    section: {
-      header: {
-        prefix: "\n",
-        postfix: "\n\n"
-      },
-      body: {
-        prefix: '',
-        postfix: ''
-      }
-    }
+    primary_bullet: { prefix: '- ', postfix: "\n" },
+    sub_bullet:     { prefix: '  · ', postfix: "\n" },
+    list_open:      '',
+    list_close:     '',
+    section_header: { prefix: "\n", postfix: ":\n\n" },
+    link_style:     :none, # NO links — Firebase tester mails can't reach sosimple
+    sub_list_break: ''
   },
   slack_markdown: {
-    spacer: "\n\n_____________________________________________________________",
-    bullet_point: {
-      prefix: '• ',
-      postfix: "\n"
-    },
-    section: {
-      header: {
-        prefix: "\n",
-        postfix: "\n\n"
-      },
-      body: {
-        prefix: '',
-        postfix: ''
-      }
-    }
+    primary_bullet: { prefix: '• ', postfix: "\n" },
+    sub_bullet:     { prefix: '   ◦ ', postfix: "\n" },
+    list_open:      '',
+    list_close:     '',
+    section_header: { prefix: "\n*", postfix: ":*\n\n" },
+    link_style:     :slack,
+    sub_list_break: ''
   }
 }.freeze
 
-def _smf_standard_changelog(changelog, changelog_format)
-  standard_changelog = ''
-
-  case changelog_format
-  when :markdown
-    standard_changelog = changelog.join("\n")
-  when :slack_markdown
-    standard_changelog =
-        changelog.map { |commit|
-          FORMAT_ELEMENTS[:slack_markdown][:bullet_point][:prefix] +
-          commit.gsub('- ', '') +
-          FORMAT_ELEMENTS[:slack_markdown][:bullet_point][:postfix]
-        }.join('')
-  when :html
-    standard_changelog =
-      FORMAT_ELEMENTS[:html][:section][:body][:prefix] +
-      changelog.map { |commit|
-        FORMAT_ELEMENTS[:html][:bullet_point][:prefix] +
-        commit.gsub('- ', '') +
-        FORMAT_ELEMENTS[:html][:bullet_point][:postfix]
-      }.join('')
-    FORMAT_ELEMENTS[:html][:section][:body][:postfix]
-  end
-
-  standard_changelog
-end
-
-def _smf_section_header(title, changelog_format)
-  FORMAT_ELEMENTS[changelog_format][:section][:header][:prefix] +
-  title +
-  FORMAT_ELEMENTS[changelog_format][:section][:header][:postfix]
-end
-
-def _smf_normal_tickets_section(tickets, changelog_format)
-
-  section = _smf_section_header('Tickets:', changelog_format)
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:prefix]
-
-  tickets[:normal].sort_by! { |ticket| ticket[:tag] }
-  tickets[:normal].each do |ticket|
-    related = _smf_linked_tickets_string(ticket[:linked_tickets], changelog_format)
-    ticket_linked =
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:prefix] +
-      _smf_ticket_to_link(ticket, changelog_format) + related +
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:postfix]
-    section += ticket_linked
-  end
-
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:postfix]
-
-  section
-end
-
-def _smf_related_prs_section(tickets, changelog_format)
-
-  section = _smf_section_header("Related Pull Requests:", changelog_format)
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:prefix]
-
-  tickets[:pr].sort_by! { |pr_tag| pr_tag[:tag] }
-  tickets[:pr].each do |pr|
-    ticket_linked =
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:prefix] +
-      _smf_ticket_to_link(pr, changelog_format, false) +
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:postfix]
-    section += ticket_linked
-  end
-
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:postfix]
-
-  section
-end
-
-def _smf_linked_tickets_section(tickets, changelog_format)
-  section = _smf_section_header('Linked Tickets:', changelog_format)
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:prefix]
-
-  tickets[:linked].sort_by! { |ticket| ticket[:tag] }
-  tickets[:linked].each do |ticket|
-    section +=
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:prefix] +
-      _smf_ticket_to_link(ticket, changelog_format) +
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:postfix]
-  end
-
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:postfix]
-
-  section
-end
-
-def _smf_unknown_tickets_section(tickets, changelog_format)
-  section = _smf_section_header('Unknown Tickets:', changelog_format)
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:prefix]
-
-  tickets[:unknown].sort_by! { |ticket| ticket[:tag] }
-  tickets[:unknown].each do |ticket|
-    section +=
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:prefix] +
-      ticket[:tag] +
-      FORMAT_ELEMENTS[changelog_format][:bullet_point][:postfix]
-  end
-
-  section += FORMAT_ELEMENTS[changelog_format][:section][:body][:postfix]
-
-  section
-end
+# ---------------------------------------------------------------------------
+# Public entry point — same signature as before, new output.
+# ---------------------------------------------------------------------------
 
 def _smf_generate_changelog(changelog, tickets, changelog_format)
-  standard_changelog = changelog.nil? ? '' : _smf_standard_changelog(changelog, changelog_format)
-  spacer = changelog.nil? ? '' : FORMAT_ELEMENTS[changelog_format][:spacer]
+  # Normalise inputs. A nil changelog is a legitimate call shape used by
+  # smf_danger.rb to ask for just the ticket summary — treat it as no
+  # commits and continue, rather than returning ''. Tickets still render.
+  changelog_lines = if changelog.nil?
+                      []
+                    elsif changelog.is_a?(Array)
+                      changelog
+                    else
+                      [changelog.to_s]
+                    end
+  tickets ||= {}
+  normal_tickets = (tickets[:normal] || []).dup
+  fmt = FORMAT_ELEMENTS[changelog_format]
+  return '' if fmt.nil?
+  return '' if normal_tickets.empty? && changelog_lines.empty?
 
-  normal_tickets = _smf_normal_tickets_section(tickets, changelog_format)
-  linked_tickets = _smf_linked_tickets_section(tickets, changelog_format)
-  related_prs = _smf_related_prs_section(tickets, changelog_format)
-  unknown_tickets = _smf_unknown_tickets_section(tickets, changelog_format)
+  # Per-tag commit map built locally via PURE regex matching.
+  # We intentionally do not call smf_get_ticket_tags_with_commits_from_changelog
+  # here — that helper performs a GitHub API call per merge commit
+  # (_smf_find_ticket_tags_in_related_pr) which we want to avoid during
+  # formatter execution. Pure regex on the commit line is sufficient for
+  # attribution; merge commits without a Jira tag in the title fall through
+  # to the orphan section.
+  commits_by_tag = _smf_build_commits_by_tag(changelog_lines)
 
-  spacer = '' if tickets[:normal].empty? and
-                tickets[:linked].empty? and
-                tickets[:unknown].empty? and
-                tickets[:pr].empty?
-  normal_tickets = '' if tickets[:normal].empty?
-  linked_tickets = '' if tickets[:linked].empty?
-  related_prs = '' if tickets[:pr].empty?
-  unknown_tickets = '' if tickets[:unknown].empty?
+  # Sort tickets by tag for deterministic output.
+  normal_tickets.sort_by! { |t| t[:tag].to_s }
 
-  standard_changelog + spacer + normal_tickets + linked_tickets + related_prs + unknown_tickets
-end
+  output_parts = []
+  output_parts << fmt[:list_open] unless fmt[:list_open].empty?
 
-def _smf_linked_tickets_string(related_tickets, changelog_format)
-  return '' if related_tickets.empty?
-
-  related = ' (linked tickets: '
-  related_tickets.each do |related_ticket|
-    related += _smf_ticket_to_link(related_ticket, changelog_format,false) + ', '
+  normal_tickets.each do |ticket|
+    output_parts << _smf_render_ticket_block(ticket, commits_by_tag[ticket[:tag]], fmt)
   end
 
-  related.chop.chop + ')'
+  output_parts << fmt[:list_close] unless fmt[:list_close].empty?
+
+  # Orphan commits — those without any recognised ticket tag.
+  orphans = _smf_orphan_commits(changelog_lines)
+  if orphans.any?
+    output_parts << _smf_render_section_header('Sonstige Änderungen', fmt)
+    output_parts << fmt[:list_open] unless fmt[:list_open].empty?
+    orphans.each { |line| output_parts << _smf_render_orphan_line(line, fmt) }
+    output_parts << fmt[:list_close] unless fmt[:list_close].empty?
+  end
+
+  output_parts.join.strip
 end
 
-def _smf_ticket_to_link(ticket, changelog_format, use_title = true)
-  ticket_string = ticket[:tag]
+# Build { tag => [cleaned_commit_msg, ...] } map without any network calls.
+# Mirrors the regex/cleanup logic of smf_get_ticket_tags_with_commits_from_changelog
+# but skips the per-commit GitHub round-trip.
+def _smf_build_commits_by_tag(changelog_lines)
+  map = {}
+  changelog_lines.each do |line|
+    next if line.nil? || line.strip.empty?
 
-  return ticket_string if ticket[:link].nil?
+    tags = _smf_find_ticket_tags_in(line)
+    next if tags.empty?
 
-  ticket_string += ": #{ticket[:title]}" if use_title
+    cleaned = line
+      .sub(/\A-\s*/, '')
+      .strip
+
+    tags.uniq.each do |tag|
+      stripped = cleaned
+        .sub(/#{Regexp.escape(tag)}\s*[:\-]?\s*/i, '')
+        .sub(/\A\s*[:\-]\s*/, '')
+        .strip
+      next if stripped.empty?
+
+      (map[tag] ||= []) << stripped
+    end
+  end
+  map
+end
+
+# ---------------------------------------------------------------------------
+# Standard changelog renderer — kept for callers that still want the
+# raw commit list (e.g. some other lanes). Output is just the commit lines
+# joined per-format, with no aggregation / no Tickets section.
+# ---------------------------------------------------------------------------
+
+def _smf_standard_changelog(changelog, changelog_format)
+  return '' if changelog.nil? || changelog.empty?
+
   case changelog_format
-  when :html
-    ticket_link =  "<a href=\"#{ticket[:link]}\">#{ticket_string}</a>"
   when :markdown
-    ticket_link = "[#{ticket_string}](#{ticket[:link]})"
+    changelog.join("\n")
   when :slack_markdown
-    ticket_link = "<#{ticket[:link]}|#{ticket_string}>"
+    changelog.map { |commit| "• #{commit.gsub(/\A-\s*/, '')}\n" }.join
+  when :html
+    '<ul>' + changelog.map { |commit| "<li>#{commit.gsub(/\A-\s*/, '')}</li>" }.join + '</ul>'
+  else
+    changelog.join("\n")
   end
+end
 
-  ticket_link
+# ---------------------------------------------------------------------------
+# Internal helpers (CBENEFIOS-2508)
+# ---------------------------------------------------------------------------
+
+def _smf_render_ticket_block(ticket, commit_messages, fmt)
+  tag = ticket[:tag].to_s
+  title = ticket[:title].to_s
+  link = ticket[:link]
+
+  headline = _smf_format_ticket_headline(tag, title, link, fmt)
+  sub_bullets = _smf_format_sub_bullets(commit_messages || [], title, fmt)
+
+  case fmt[:link_style]
+  when :html
+    "#{fmt[:primary_bullet][:prefix]}#{headline}#{sub_bullets}#{fmt[:primary_bullet][:postfix]}"
+  else
+    "#{fmt[:primary_bullet][:prefix]}#{headline}#{fmt[:primary_bullet][:postfix]}#{sub_bullets}"
+  end
+end
+
+def _smf_format_ticket_headline(tag, title, link, fmt)
+  rendered_tag = _smf_render_tag(tag, link, fmt)
+  return rendered_tag if title.nil? || title.empty?
+
+  "#{rendered_tag}: #{title}"
+end
+
+def _smf_render_tag(tag, link, fmt)
+  case fmt[:link_style]
+  when :html
+    return tag if link.nil? || link.empty?
+
+    "<a href=\"#{link}\">#{tag}</a>"
+  when :slack
+    return tag if link.nil? || link.empty?
+
+    "<#{link}|#{tag}>"
+  else
+    tag
+  end
+end
+
+def _smf_format_sub_bullets(commit_messages, ticket_title, fmt)
+  cleaned = commit_messages.map { |m| m.to_s.strip }.reject(&:empty?).uniq
+  cleaned = cleaned.reject { |m| _smf_messages_similar?(m, ticket_title) }
+  return '' if cleaned.empty?
+
+  case fmt[:link_style]
+  when :html
+    sub = cleaned.map { |m| "<li>#{m}</li>" }.join
+    "<ul>#{sub}</ul>"
+  else
+    cleaned.map { |m| "#{fmt[:sub_bullet][:prefix]}#{m}#{fmt[:sub_bullet][:postfix]}" }.join
+  end
+end
+
+def _smf_messages_similar?(message, ticket_title)
+  return false if message.nil? || ticket_title.nil?
+  return false if message.empty? || ticket_title.empty?
+
+  normalised_message = _smf_normalise(message)
+  normalised_title = _smf_normalise(ticket_title)
+
+  return true if normalised_message == normalised_title
+  return true if normalised_title.include?(normalised_message) && normalised_message.length >= 20
+  return true if normalised_message.include?(normalised_title) && normalised_title.length >= 20
+
+  false
+end
+
+def _smf_normalise(string)
+  string.downcase.gsub(/\s+/, ' ').gsub(/[^a-z0-9\s]/i, '').strip
+end
+
+def _smf_orphan_commits(changelog_lines)
+  # PURE regex — no PR-body fetching. A commit whose title doesn't directly
+  # reference a Jira tag goes under "Sonstige Änderungen", even if the PR
+  # body would have one. Acceptable: such commits are usually maintenance,
+  # config changes, dependency bumps.
+  changelog_lines.select do |line|
+    next false if line.nil? || line.strip.empty?
+
+    _smf_find_ticket_tags_in(line).empty?
+  end
+end
+
+def _smf_render_orphan_line(line, fmt)
+  body = line.to_s.sub(/\A-\s*/, '').strip
+  return '' if body.empty?
+
+  case fmt[:link_style]
+  when :html
+    "<li>#{body}</li>"
+  else
+    "#{fmt[:primary_bullet][:prefix]}#{body}#{fmt[:primary_bullet][:postfix]}"
+  end
+end
+
+def _smf_render_section_header(title, fmt)
+  "#{fmt[:section_header][:prefix]}#{title}#{fmt[:section_header][:postfix]}"
 end


### PR DESCRIPTION
Jira: [CBENEFIOS-2508](https://sosimple.atlassian.net/browse/CBENEFIOS-2508) — follow-up to the afmcli migration ([CBENEFIOS-2504](https://sosimple.atlassian.net/browse/CBENEFIOS-2504) / [CBENEFIOS-2505](https://sosimple.atlassian.net/browse/CBENEFIOS-2505) / [CBENEFIOS-2506](https://sosimple.atlassian.net/browse/CBENEFIOS-2506) / [CBENEFIOS-2507](https://sosimple.atlassian.net/browse/CBENEFIOS-2507))

## What changed

`_smf_generate_changelog` produces a new, ticket-aggregated layout. Each Jira ticket becomes the primary bullet (carrying the Jira title which already includes any APP-XXXX cross-ref), and commits that reference the ticket appear underneath as indented sub-bullets. Orphan commits (no Jira tag in the title) collect at the bottom under "Sonstige Änderungen:".

### Markdown — what Firebase tester emails will see

```
- CBENEFIOS-2299: Map: Location permission UX with info-banner and settings deep-link
  · Unify location-permission-banner copy across iOS + Android (#746)
- CBENEFIOS-2300: APP-1154 Android: Map Permission info-banner with settings deep-link
  · Android — switch banner icon to NearMeDisabled for iOS parity (#758)
  · Location Permission prompt (#744)
- CBENEFIOS-2342: APP-1202 PM: POI-Überprüfung auf Karte (Domino's, Circle K, …)
  · Fix offer-detail coordinate format mismatch with web (#743)
- CBENEFIOS-2463: APP-1264 Android: offer tile — name without icon, address as map link
- CBENEFIOS-2495: APP-1297 Android: Native Map — remove user-location action icons
  · Disable Google Maps SDK built-in map toolbar (#742)
  · Remove the navigate to location in maps

Sonstige Änderungen:

- Bump fastlane to 2.236.1
- Update Gemfile.lock
```

### Why markdown has no Jira links

The first production tester emails (build #449 CH_beta + de_beta) used sosimple.atlassian.net links. CB-side colleagues can't reach those — the link looks tappable but lands them at a "sign in" page. Plain text is more honest. HTML and Slack outputs still link (those go to internal channels).

## What is removed

- **"Tickets:" section header** — every primary bullet IS a ticket entry now.
- **"Linked Tickets:" block** — APP-XXXX is inline in the headline (comes from the Jira title).
- **"Unknown Tickets:" block** — not useful for testers.
- **"Related Pull Requests:" block** — PR refs already in sub-bullets via `(#NNN)`.
- **Duplicate Tickets block** — collapses inherently; there's only one block now.
- **`----` spacers** — no section dividers needed.

## Performance

Deliberately does NOT call `smf_get_ticket_tags_with_commits_from_changelog` inside the formatter, because that helper performs a GitHub API call per merge commit to detect ticket tags in the PR body. Instead, attribution is via pure regex (`_smf_find_ticket_tags_in`) against the commit title. Merge commits whose title lacks a Jira tag fall into "Sonstige Änderungen" — acceptable trade-off for fastlane-internal formatter execution. No new network requests.

## Fleet impact (Q3a in the design discussion)

All apps consuming `_smf_generate_changelog` get the new format. Other apps that may have relied on the explicit `Tickets:` / `Linked Tickets:` / `Unknown Tickets:` headers will see them disappear. The aggregated format is arguably cleaner for all use cases, but if some app strongly depends on the old headers, this is a coordinated change moment.

## Dead code removed

```
_smf_normal_tickets_section
_smf_linked_tickets_section
_smf_related_prs_section
_smf_unknown_tickets_section
_smf_linked_tickets_string
_smf_ticket_to_link        (replaced by per-format helpers)
```

`_smf_standard_changelog` retained — still used for raw commit-list contexts that don't aggregate.

## Compat: smf_danger

The `smf_danger.rb` call `_smf_generate_changelog(nil, tickets, :html)` is preserved: nil changelog with populated tickets returns just the ticket bullets (no orphans section). Empty input across the board returns `''`.

## Test plan

- [x] Pure-Ruby smoke against the realistic CB Android #451 dataset (14 tickets + 2 orphan commits, three formats) — all three render as designed
- [ ] Re-trigger CB Android `de_beta` on `cibre-studio` after merge → verify the Firebase tester email shows the new format
- [ ] Spot-check one Slack notification (smf_send_message lane) to confirm slack_markdown rendering
- [ ] Spot-check Danger output if any open PR in the fleet runs it

## Diff

```
1 file changed, 207 insertions(+), 160 deletions(-)
commons/smf_git_changelog/smf_changelog_formatter.rb
```

Full smoke-test output reproduced in commit message.

## Rollback

`git revert <merge>` restores the old structured format. Anthropic credential, AI release notes config, and afmcli installation are all unaffected.

[CBENEFIOS-2508]: https://sosimple.atlassian.net/browse/CBENEFIOS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2504]: https://sosimple.atlassian.net/browse/CBENEFIOS-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2505]: https://sosimple.atlassian.net/browse/CBENEFIOS-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2506]: https://sosimple.atlassian.net/browse/CBENEFIOS-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2507]: https://sosimple.atlassian.net/browse/CBENEFIOS-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ