### PR TITLE
CBENEFIOS-2510: Fix changelog attribution + defensive orphan cleanup

### DIFF
--- a/commons/smf_git_changelog/smf_changelog_formatter.rb
+++ b/commons/smf_git_changelog/smf_changelog_formatter.rb
@@ -55,7 +55,7 @@ FORMAT_ELEMENTS = {
 # Public entry point — same signature as before, new output.
 # ---------------------------------------------------------------------------
 
-def _smf_generate_changelog(changelog, tickets, changelog_format)
+def _smf_generate_changelog(changelog, tickets, changelog_format, commits_by_tag: nil)
   # Normalise inputs. A nil changelog is a legitimate call shape used by
   # smf_danger.rb to ask for just the ticket summary — treat it as no
   # commits and continue, rather than returning ''. Tickets still render.
@@ -72,14 +72,19 @@ def _smf_generate_changelog(changelog, tickets, changelog_format)
   return '' if fmt.nil?
   return '' if normal_tickets.empty? && changelog_lines.empty?
 
-  # Per-tag commit map built locally via PURE regex matching.
-  # We intentionally do not call smf_get_ticket_tags_with_commits_from_changelog
-  # here — that helper performs a GitHub API call per merge commit
-  # (_smf_find_ticket_tags_in_related_pr) which we want to avoid during
-  # formatter execution. Pure regex on the commit line is sufficient for
-  # attribution; merge commits without a Jira tag in the title fall through
-  # to the orphan section.
-  commits_by_tag = _smf_build_commits_by_tag(changelog_lines)
+  # Per-tag commit map. CBENEFIOS-2510: prefer the canonical map computed
+  # by the caller (with PR-body lookup via _smf_find_ticket_tags_in_related_pr)
+  # — that helper attributes commits where the CBENEFIOS-XXXX only appears
+  # in the PR body, not the commit title. Real CB builds use squash-merge
+  # PR titles that often have only the PR ref ("(#758)") and no explicit
+  # CBENEFIOS-XXXX prefix in the merge subject.
+  #
+  # When the caller doesn't pass commits_by_tag (e.g. smf_danger calling
+  # with changelog=nil), fall back to PURE regex matching on each commit
+  # line. This is a worse but no-network attribution that still works for
+  # commits where the tag is explicitly in the title.
+  commits_by_tag ||= _smf_build_commits_by_tag(changelog_lines)
+  attributed_lines = Set.new(commits_by_tag.values.flatten.map(&:to_s))
 
   # Sort tickets by tag for deterministic output.
   normal_tickets.sort_by! { |t| t[:tag].to_s }
@@ -93,8 +98,9 @@ def _smf_generate_changelog(changelog, tickets, changelog_format)
 
   output_parts << fmt[:list_close] unless fmt[:list_close].empty?
 
-  # Orphan commits — those without any recognised ticket tag.
-  orphans = _smf_orphan_commits(changelog_lines)
+  # Orphan commits — those without any recognised ticket tag AND not
+  # attributed via the canonical commits_by_tag map (PR-body lookup).
+  orphans = _smf_orphan_commits(changelog_lines, commits_by_tag)
   if orphans.any?
     output_parts << _smf_render_section_header('Sonstige Änderungen', fmt)
     output_parts << fmt[:list_open] unless fmt[:list_open].empty?
@@ -228,20 +234,38 @@ def _smf_normalise(string)
   string.downcase.gsub(/\s+/, ' ').gsub(/[^a-z0-9\s]/i, '').strip
 end
 
-def _smf_orphan_commits(changelog_lines)
-  # PURE regex — no PR-body fetching. A commit whose title doesn't directly
-  # reference a Jira tag goes under "Sonstige Änderungen", even if the PR
-  # body would have one. Acceptable: such commits are usually maintenance,
-  # config changes, dependency bumps.
+def _smf_orphan_commits(changelog_lines, commits_by_tag = nil)
+  # A line is an orphan if NO ticket attribution applies to it.
+  # CBENEFIOS-2510: we now check both (a) direct regex match in the line
+  # AND (b) inclusion in the canonical commits_by_tag map (which uses
+  # PR-body lookup). A commit attributed to ANY ticket — even via PR body
+  # only — is not an orphan.
+  attributed_bodies = if commits_by_tag.nil? || commits_by_tag.empty?
+                        Set.new
+                      else
+                        Set.new(commits_by_tag.values.flatten.map(&:to_s))
+                      end
+
   changelog_lines.select do |line|
     next false if line.nil? || line.strip.empty?
+    next false unless _smf_find_ticket_tags_in(line).empty?
 
-    _smf_find_ticket_tags_in(line).empty?
+    cleaned_body = _smf_strip_bullet_prefixes(line)
+    next false if attributed_bodies.include?(cleaned_body)
+
+    true
   end
 end
 
 def _smf_render_orphan_line(line, fmt)
-  body = line.to_s.sub(/\A-\s*/, '').strip
+  # CBENEFIOS-2510: strip ALL leading bullet-like chars defensively.
+  # In CB production builds the changelog file gets re-processed in a
+  # later stage (mechanism still unidentified — possibly
+  # smf_atlassian_base_urls or a sibling generate_changelog run after
+  # the first write) and our own sub-bullet output (`  · {msg}`) shows
+  # back up as input. Stripping defensively keeps the orphan section clean
+  # regardless of how dirty the input is.
+  body = _smf_strip_bullet_prefixes(line)
   return '' if body.empty?
 
   case fmt[:link_style]
@@ -250,6 +274,20 @@ def _smf_render_orphan_line(line, fmt)
   else
     "#{fmt[:primary_bullet][:prefix]}#{body}#{fmt[:primary_bullet][:postfix]}"
   end
+end
+
+# Strip any combination of leading bullet markers and whitespace.
+# Handles "- ", "  · ", "• ", "   ◦ ", "- · " (double-stamped from a
+# reprocessing pass), etc. Iterates so nested combinations all peel.
+def _smf_strip_bullet_prefixes(line)
+  body = line.to_s
+  loop do
+    new_body = body.sub(/\A\s*[\-•·◦\*]\s+/, '')
+    break if new_body == body
+
+    body = new_body
+  end
+  body.strip
 end
 
 def _smf_render_section_header(title, fmt)

--- a/commons/smf_git_changelog/smf_git_changelog.rb
+++ b/commons/smf_git_changelog/smf_git_changelog.rb
@@ -140,10 +140,17 @@ private_lane :smf_git_changelog do |options|
   changelog = "#{changelog[0..20_000]}#{'\\n...'}" if changelog.length > 20_000
   changelog = changelog.split("\n")
 
+  # CBENEFIOS-2510: compute the canonical commits_by_tag once (this is the
+  # path that does the GitHub PR-body lookup for commits whose CBENEFIOS-XXXX
+  # is only in the PR body, not the title). Pass it to all three format
+  # calls so we don't pay the network cost three times.
+  commits_attribution = smf_get_ticket_tags_with_commits_from_changelog(changelog)
+  commits_by_tag = commits_attribution[:commits_by_tag] || {}
+
   # Convert changelog to different output formats
-  html_changelog = _smf_generate_changelog(changelog, tickets, :html)
-  markdown_changelog = _smf_generate_changelog(changelog, tickets, :markdown)
-  slack_changelog = _smf_generate_changelog(changelog, tickets, :slack_markdown)
+  html_changelog = _smf_generate_changelog(changelog, tickets, :html, commits_by_tag: commits_by_tag)
+  markdown_changelog = _smf_generate_changelog(changelog, tickets, :markdown, commits_by_tag: commits_by_tag)
+  slack_changelog = _smf_generate_changelog(changelog, tickets, :slack_markdown, commits_by_tag: commits_by_tag)
   all_ticket_tags = (ticket_tags + devops_ticket_tags).uniq.join(' ')
 
   smf_write_changelog(


### PR DESCRIPTION
Jira: [CBENEFIOS-2510](https://sosimple.atlassian.net/browse/CBENEFIOS-2510) — hotfix of [CBENEFIOS-2508](https://sosimple.atlassian.net/browse/CBENEFIOS-2508) / PR #275

## Bugs surfaced in CB Android #456 PT_beta tester email

```
Release notes for 3.6.0 (4145) PT (4145)
- CBENEFIOS-2299: Map: Location permission UX with info-banner and settings deep-link
- CBENEFIOS-2300: APP-1154 Android: Map Permission info-banner with settings deep-link
- CBENEFIOS-2342: APP-1202 PM: POI-Überprüfung auf Karte ...
- CBENEFIOS-2463: APP-1264 Android: offer tile — name without icon, address as map link
- CBENEFIOS-2495: APP-1297 Android: Native Map — remove user-location action icons
- CBENEFIOS-2499: Android: Native Map — surface device-wide Location Services OFF
- CBENEFIOS-2500: iOS + Android: Map Offer Detail Page parity alignment

Sonstige Änderungen:

- · De-theme offer card (iOS + Android) via new darkText token (#741)
- · Android — switch banner icon to NearMeDisabled for iOS parity (#758)
- · Location Permission prompt (#744)
- · Fix offer-detail coordinate format mismatch with web (#743)
...
```

Two issues:
1. **No sub-bullets** under any ticket. All 10 commits ended up as "Sonstige Änderungen".
2. **`- · {body}` double-stamp** on every orphan — middle dot bleeding through.

## Root causes

### Bug 1 — attribution mismatch with the rest of the gem

`_smf_generate_changelog` previously used **pure regex** (`_smf_find_ticket_tags_in`) on each commit line. In CB squash-merge titles, the CBENEFIOS-XXXX is usually only in the PR body (`Merge pull request #758 from feature/...` becomes the squash title without the tag). The rest of the gem detects this via `_smf_find_ticket_tags_in_related_pr` — a GitHub-API PR-body lookup. The formatter intentionally skipped that helper to save a round-trip — wrong call. Build log of #456 confirms: every PR (#741–#758) gets its CBENEFIOS-XXXX via `Analysing merge commit for PR-NNN ...` (PR-body), and ZERO commits have the tag literal in their squash title.

### Bug 2 — `- · ` double-stamp

`·` exists ONLY in my own FORMAT_ELEMENTS for markdown sub_bullet. Some reprocessing pass between the smf_super_generate_changelog run and the smf_read_changelog read feeds my formatter output back as input. Old orphan renderer only stripped a single leading `- `, leaving the `· ` from a previous run's sub-bullet in the body — output `- · {body}`. The upstream re-feed mechanism is still unidentified (suspected: smf_atlassian_base_urls writes the file with rebased URLs, or a sibling generate_changelog run happens). Rather than chase it, this PR makes the formatter defensive.

## Fixes

### `_smf_generate_changelog` — new optional `commits_by_tag` parameter

```ruby
def _smf_generate_changelog(changelog, tickets, changelog_format, commits_by_tag: nil)
```

If passed, used as-is (caller controls attribution). If omitted, falls back to the regex-only computation (preserves smf_danger.rb's nil-changelog call shape).

### `smf_git_changelog.rb` — compute once, pass three times

```ruby
commits_attribution = smf_get_ticket_tags_with_commits_from_changelog(changelog)
commits_by_tag = commits_attribution[:commits_by_tag] || {}

html_changelog = _smf_generate_changelog(changelog, tickets, :html, commits_by_tag: commits_by_tag)
markdown_changelog = _smf_generate_changelog(changelog, tickets, :markdown, commits_by_tag: commits_by_tag)
slack_changelog = _smf_generate_changelog(changelog, tickets, :slack_markdown, commits_by_tag: commits_by_tag)
```

The canonical helper does the PR-body lookup once for all 3 format calls. Network cost is the same as before (the helper was already invoked by `_smf_get_release_notes_for_firebase` for the AI path — same call, same caching effect).

### `_smf_strip_bullet_prefixes` — defensive orphan cleanup

```ruby
def _smf_strip_bullet_prefixes(line)
  body = line.to_s
  loop do
    new_body = body.sub(/\A\s*[\-•·◦\*]\s+/, '')
    break if new_body == body
    body = new_body
  end
  body.strip
end
```

Iteratively peels any combination of `-`, `·`, `•`, `◦`, `*` with whitespace. Handles double-stamped (`- · `), triple-stamped (`- · · `), or any leading-bullet mess the reprocessing might produce.

### `_smf_orphan_commits` — accept attribution map

```ruby
def _smf_orphan_commits(changelog_lines, commits_by_tag = nil)
  attributed_bodies = Set.new(commits_by_tag.values.flatten.map(&:to_s))
  changelog_lines.select do |line|
    next false if line.nil? || line.strip.empty?
    next false unless _smf_find_ticket_tags_in(line).empty?
    cleaned_body = _smf_strip_bullet_prefixes(line)
    next false if attributed_bodies.include?(cleaned_body)
    true
  end
end
```

A line is an orphan only if neither regex match in title NOR membership in the canonical attribution map applies. Bullet-stripped body comparison handles dirty re-feed inputs.

## Smoke tests

```
=== MARKDOWN with canonical commits_by_tag (realistic PT_beta scenario) ===
- CBENEFIOS-2285: Design tokens: dark text on offer cards
  · De-theme offer card (iOS + Android) via new darkText token (#741)
- CBENEFIOS-2300: APP-1154 Android: Map Permission info-banner
  · Android — switch banner icon to NearMeDisabled for iOS parity (#758)
  · Location Permission prompt (#744)
- CBENEFIOS-2342: APP-1202 PM: POI-Überprüfung
  · Fix offer-detail coordinate format mismatch with web (#743)
- CBENEFIOS-2406: App Info Cache visibility for dev options
  · iOS Dev Options — surface App Info cache contents (#753)
- CBENEFIOS-2500: iOS + Android: Map Offer Detail Page parity
  · Android — log missing offerLink (#750)

Sonstige Änderungen:

- Bump fastlane to 2.236.1

=== Dirty-input defensive cleanup ===
Sonstige Änderungen:
- Some commit                ← was "- · Some commit"
- Some other commit           ← was "- Some other commit"
- And another                 ← was "  · And another"
- unicode bullet              ← was "• unicode bullet"
- slack-style sub             ← was "   ◦ slack-style sub"
```

## Test plan

- [x] Smoke tests pass (commits_by_tag-driven attribution + defensive orphan strip)
- [ ] Re-trigger CB Android pt_beta on `cibre-studio` after merge → tester mail shows sub-bullets under tickets, no `- · ` doubled prefix in Sonstige Änderungen, single source of truth, no duplication
- [ ] Spot-check Slack notification + Danger HTML on next PR run

## Diff

```
2 files changed, 66 insertions(+), 21 deletions(-)
  commons/smf_git_changelog/smf_changelog_formatter.rb
  commons/smf_git_changelog/smf_git_changelog.rb
```

[CBENEFIOS-2510]: https://sosimple.atlassian.net/browse/CBENEFIOS-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBENEFIOS-2508]: https://sosimple.atlassian.net/browse/CBENEFIOS-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ