### PR TITLE
CBENEFIOS-2511: strip bullet contamination from attribution map

### DIFF
--- a/commons/smf_git_changelog/smf_changelog_formatter.rb
+++ b/commons/smf_git_changelog/smf_changelog_formatter.rb
@@ -84,6 +84,20 @@ def _smf_generate_changelog(changelog, tickets, changelog_format, commits_by_tag
   # line. This is a worse but no-network attribution that still works for
   # commits where the tag is explicitly in the title.
   commits_by_tag ||= _smf_build_commits_by_tag(changelog_lines)
+
+  # CBENEFIOS-2511: defensive normalization of attribution map values.
+  # The yet-unidentified re-feed mechanism contaminates the changelog
+  # input with leading bullet chars from our own previous output ("- · X").
+  # The canonical attribution helper (smf_get_ticket_tags_with_commits_from_changelog)
+  # strips the leading "- " but not "· ", so commits_by_tag values may carry
+  # "· " prefixes that contaminate:
+  #   - sub-bullet rendering: shows "- · · {body}" double-dot
+  #   - orphan dedup: comparison key mismatch → same commit appears both
+  #     as sub-bullet AND as orphan
+  # Strip them at the boundary here, once for all downstream uses.
+  commits_by_tag = commits_by_tag.transform_values do |msgs|
+    (msgs || []).map { |m| _smf_strip_bullet_prefixes(m) }.reject(&:empty?)
+  end
   attributed_lines = Set.new(commits_by_tag.values.flatten.map(&:to_s))
 
   # Sort tickets by tag for deterministic output.


### PR DESCRIPTION
## Summary

Defensive normalization of `commits_by_tag` values right after the canonical attribution helper produces them. The re-feed mechanism contaminates input lines with leading bullet chars from our own previous output (`- · X`). The canonical helper strips `- ` but not `· `, so `commits_by_tag` values carry `· ` prefixes that contaminate:

- **Sub-bullet rendering**: `  · ` prefix + `· {body}` → `  · · {body}` — visible in Firebase tester mails as doubled middle-dot (build #459 TR_beta).
- **Orphan dedup**: `attributed_bodies` set keyed on contaminated message, orphan `cleaned_body` keyed on stripped message → mismatch → same commit appears as sub-bullet AND as orphan in "Sonstige Änderungen".

The single-line fix: run `_smf_strip_bullet_prefixes` over all values once at the boundary, so both downstream uses see the same clean key.

## Test plan

- [x] Local smoke test with exact bug input from build #459 — all 6 tickets render attributed sub-bullets cleanly with single `· ` prefix, no `Sonstige Änderungen` duplicates
- [x] Orphan-path smoke test — truly unattributed commits still appear correctly in `Sonstige Änderungen`
- [ ] Verify on next real CB build (it_beta or tr_beta) that Firebase tester mail shows clean output