### PR TITLE
CBENEFIOS-2694: require 'cgi' in Dangerfile — fix danger-xcode_summary CGI.parse crash

### DIFF
--- a/commons/smf_danger/Dangerfile
+++ b/commons/smf_danger/Dangerfile
@@ -1,4 +1,8 @@
 require 'json'
+require 'cgi'  # CBENEFIOS-2694: danger-xcode_summary calls CGI.parse but does not
+# require 'cgi'. Since cgi 0.5.x split the library, only cgi/escape is ambiently
+# loaded and CGI.parse (in cgi/core) is missing -> NoMethodError. Requiring cgi
+# fully loads core in every cgi version. (A version pin does NOT fix this.)
 
 puts "Danger: Bump Type"
 if ENV['MULTIPLE_BUMP_TYPES_ERROR'] == 'true'


### PR DESCRIPTION
## Problem
All iOS PR builds fail while parsing the Dangerfile:
```
danger-xcode_summary-1.5.0/lib/xcode_summary/plugin.rb:403: undefined method `parse' for class CGI (NoMethodError)
```

## Root cause (verified with Ruby 3.3.10)
- `danger-xcode_summary` calls `CGI.parse` but **never `require 'cgi'`** — it relies on CGI being ambiently loaded.
- The `cgi` gem 0.4.x/0.5.x **split** the library: something loads `cgi/escape` (defines the `CGI` class + escape) but **not** `cgi/core`, where `CGI.parse` lives → `CGI.parse` is undefined.
- A **version pin does NOT fix this** — tested: with only `cgi/escape` loaded, `CGI.parse` is undefined under both cgi 0.5.2 **and** 0.3.7. `require 'cgi'` (full) makes it work under every version (it loads `cgi/core`).

## Fix
Add `require 'cgi'` at the top of the Dangerfile so `cgi/core` (→ `CGI.parse`) is loaded before `danger-xcode_summary` runs. Version-agnostic, harmless.

Supersedes the ineffective cgi Gemfile pin (JPC #189, being reverted).
Ticket: CBENEFIOS-2694