### PR TITLE
EPRES-212: give each platform its own Danger identity, and fix the dead links

### DIFF
--- a/commons/smf_danger/Dangerfile
+++ b/commons/smf_danger/Dangerfile
@@ -138,6 +138,17 @@ if File.exist?(ENV['DANGER_RESULT_BUNDLE_PATH'])
   xcode_summary.inline_mode = true
   xcode_summary.ignored_files = 'Pods/**'
 
+  # EPRES-212: project_root defaults to Dir.pwd, which is the fastlane directory
+  # — for an Apple project inside a larger repository that is a subdirectory. Any
+  # warning about a file outside it then fails the prefix match and keeps its
+  # absolute path, which Danger appends to the blob URL verbatim:
+  #   blob/<sha>/Volumes/miniExtHD/workspace/.../composeApp/src/...
+  # Every such link is dead. Anchoring on the repository root makes the paths
+  # relative and the links work. Harmless where fastlane already sits at the
+  # root, since the value is then the same.
+  repository_root = `git rev-parse --show-toplevel`.strip
+  xcode_summary.project_root = repository_root unless repository_root.empty?
+
   xcode_summary.ignored_results { |result|
 
       if result.location.nil?

--- a/commons/smf_danger/smf_danger.rb
+++ b/commons/smf_danger/smf_danger.rb
@@ -74,7 +74,20 @@ private_lane :smf_danger do |options|
 
   dangerfile = "#{File.expand_path(File.dirname(__FILE__))}/Dangerfile"
   puts "Loading Dangerfile: #{dangerfile}"
+  # EPRES-212: one danger_id per platform, because a KMP repository runs this
+  # lane twice for the same pull request — once from the iOS pipeline, once from
+  # Android. Without an id both runs share Danger's default identity, so they
+  # write the same comment and the same "danger/danger" status: whichever
+  # finishes last silently replaces the other's findings. Observed on
+  # ePrescription-MP PR-76, where nine iOS warnings were overwritten two minutes
+  # later by the Android run.
+  #
+  # With an id, Danger keeps one comment and one status context per platform.
+  # Single-platform projects are unaffected apart from the context gaining a
+  # suffix; no repository in the organisation requires "danger/danger" as a
+  # status check, so nothing starts blocking.
   danger(
+      danger_id: @platform.to_s,
       github_api_token: ENV[$DANGER_GITHUB_TOKEN_KEY],
       dangerfile: dangerfile,
       verbose: true


### PR DESCRIPTION
Zwei Befunde aus einem Kotlin-Multiplatform-Repository, in dem diese Lane für **denselben** Pull Request **zweimal** läuft — einmal aus der iOS-, einmal aus der Android-Pipeline.

## 1. Danger ohne `danger_id`

Beide Läufe nutzten Dangers Standard-Identität, schrieben damit denselben Kommentar und setzten denselben Status `danger/danger`. Wer zuletzt fertig wird, ersetzt die Befunde des anderen — lautlos.

Gemessen an **ePrescription-MP PR-76**:

| | |
|---|---|
| 09:54:21 | iOS-Lauf, **9 Warnungen** |
| 09:56:15 | Android-Lauf überschreibt den Kommentar |
| Ergebnis | Die neun Warnungen hat nie jemand gesehen |

Mit `danger_id: @platform.to_s` bekommt jede Seite eigenen Kommentar und eigenen Status-Kontext.

**Für Einzelplattform-Projekte ändert sich fast nichts** — ein Kommentar bleibt ein Kommentar, nur der Status-Kontext bekommt ein Suffix. Vorher geprüft: **Kein Repository der Organisation führt `danger/danger` als Pflicht-Check**, es fängt also nichts an zu blockieren.

## 2. Tote Links bei den Xcode-Warnungen

`xcode_summary.project_root` steht standardmäßig auf `Dir.pwd` — dem fastlane-Verzeichnis. Bei einem Apple-Projekt *innerhalb* eines größeren Repositorys ist das ein Unterverzeichnis. Eine Warnung zu einer Datei außerhalb davon scheitert am Präfixvergleich und behält ihren absoluten Pfad, den Danger unverändert an die blob-URL hängt:

```
blob/<sha>/Volumes/miniExtHD/workspace/…/composeApp/src/…
```

Jeder dieser Links führt ins Leere. Die Verankerung an der Repository-Wurzel macht die Pfade relativ und die Links funktionsfähig.

Wo fastlane ohnehin an der Wurzel liegt, ist der Wert derselbe wie bisher — für diese Projekte ändert sich nichts.

## Verifikation

- `ruby -c` auf beiden Dateien: Syntax OK
- `git rev-parse --show-toplevel` aus einem Unterverzeichnis liefert die Repository-Wurzel — genau der Fall, auf dem die zweite Änderung beruht
- Branch-Schutz beider Referenzprojekte geprüft, keine Pflicht-Status-Checks

**Nicht geprüft:** ein echter Lauf. Das zeigt sich erst am nächsten PR eines Projekts, das diese Commons zieht — bei ePrescription-MP also unmittelbar, weil dort beide Pipelines laufen.

Ticket: EPRES-212