### PR TITLE
CBENEFIOS-2704: Resolve the Play Store package name from the build output

### DIFF
--- a/setup/android_setup.rb
+++ b/setup/android_setup.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 
 
 ########## PULLREQUEST CHECK LANES ##########
@@ -833,25 +835,50 @@ def copy_xml_to_default_changelog(xml_content)
 end
 
 # Helper function to get package name from build variant
+#
+# Resolution order, first source that yields a value wins:
+#   1. An explicit `package_name` in the variant's Config.json entry.
+#   2. AGP's `output-metadata.json`, matched on the Gradle variant name.
+#   3. The legacy source scraping (manifest, build.gradle, gradle.properties).
+#
+# Sources 1 and 2 return the final, fully resolved application ID *including* any
+# build-type suffix, so the `.alpha` / `.beta` suffix is appended only for the
+# legacy sources, which read pre-suffix values.
 def smf_get_package_name_from_variant(build_variant)
   UI.message("🔍 Getting package name for build variant: #{build_variant}")
-  
+
+  # 1. Explicit override — no inference at all, always wins.
+  explicit_package = smf_config_get(build_variant, :package_name)
+  unless explicit_package.nil? || explicit_package.to_s.empty?
+    UI.message("✅ Using explicit package_name from Config.json: #{explicit_package}")
+    return explicit_package.to_s
+  end
+
+  # 2. The resolved value the Android Gradle plugin itself wrote out.
+  resolved_package = extract_package_from_output_metadata(build_variant)
+  unless resolved_package.nil? || resolved_package.empty?
+    UI.message("✅ Package name for #{build_variant}: #{resolved_package}")
+    return resolved_package
+  end
+
+  # 3. Legacy source scraping. These read pre-suffix values, hence the suffix
+  # handling below.
   base_package = nil
-  
+
   # Try to extract package name from AndroidManifest.xml (most reliable for built variants)
   base_package = extract_package_from_manifest(build_variant) if base_package.nil?
-  
+
   # Fallback: try to read from build.gradle (primary source)
   base_package = extract_package_from_build_gradle(build_variant) if base_package.nil?
-  
+
   # Fallback: try to read from gradle.properties
   base_package = extract_package_from_gradle_properties if base_package.nil?
-  
+
   # If still no package found, raise error
   if base_package.nil? || base_package.empty?
-    UI.user_error!("❌ Could not extract package name from AndroidManifest.xml, build.gradle, or gradle.properties for variant: #{build_variant}")
+    UI.user_error!("❌ Could not determine the package name for variant: #{build_variant}. Build the variant first so AGP writes output-metadata.json, or set an explicit \"package_name\" in that variant's Config.json entry.")
   end
-  
+
   # Apply variant-specific suffix if needed
   case build_variant
   when /alpha/i
@@ -861,9 +888,49 @@ def smf_get_package_name_from_variant(build_variant)
   else
     package_name = base_package
   end
-  
+
   UI.message("✅ Package name for #{build_variant}: #{package_name}")
   return package_name
+end
+
+# Reads the application ID from AGP's `output-metadata.json`.
+#
+# This is the stable source: the file is written by the Android Gradle plugin
+# next to the build outputs and carries the *resolved* application ID — including
+# the build-type suffix — instead of something scraped out of source text. It is
+# located by glob and matched on `variantName`, so it survives both Gradle
+# refactors (flavors declared in a loop rather than as literal `create("x")`
+# blocks) and AGP changing its intermediates layout.
+#
+# Note: AGP writes this file for APK outputs only, not for bundles. A project that
+# exclusively builds AABs therefore falls through to the legacy sources, or should
+# set `package_name` explicitly in Config.json.
+def extract_package_from_output_metadata(build_variant)
+  gradle_variant = smf_config_get(build_variant, :variant).to_s
+  if gradle_variant.empty?
+    UI.message("⚠️ No `variant` configured for #{build_variant}; skipping output-metadata.json lookup")
+    return nil
+  end
+
+  Dir.glob("**/build/outputs/**/output-metadata.json").each do |path|
+    metadata = begin
+      JSON.parse(File.read(path))
+    rescue StandardError => e
+      UI.message("⚠️ Could not read #{path}: #{e.message}")
+      next
+    end
+
+    next unless metadata['variantName'].to_s.casecmp(gradle_variant).zero?
+
+    application_id = metadata['applicationId'].to_s
+    next if application_id.empty?
+
+    UI.message("📄 Found applicationId for '#{gradle_variant}' in #{path}")
+    return application_id
+  end
+
+  UI.message("⚠️ No output-metadata.json with variantName '#{gradle_variant}' found")
+  return nil
 end
 
 # Helper function to extract package name from AndroidManifest.xml


### PR DESCRIPTION
## CBENEFIOS-2704 — Resolve the Play Store package name from the build output

### Problem
`smf_get_package_name_from_variant` determined the Play Store package name by **scraping source text**. `extract_flavor_application_id` only matches a literal shape:

```kotlin
create("poland") { applicationId = "pl.corporatebenefits.app" }
```

CorporateBenefits generates its nine country flavors **in a loop** (`countries.forEach { create(country.name) { this.applicationId = country.applicationId } }`), so nothing matched. The lookup fell through to the `defaultConfig` applicationId and uploaded **every non-German AAB against the German Play listing**:

```
Google Api Error: Invalid request - APK has the wrong package name.
```

Affected all 8 non-DE countries (AT, BE, CH, ES, IT, PL, PT, TR), live and alpha/beta. DE worked only by coincidence.

`extract_package_from_manifest` would have caught it, but it only looks under `app/…` — CB's module is `androidApp`.

### Fix
Resolve from **AGP's `output-metadata.json`** — written by the Android Gradle plugin next to the build outputs, carrying the *fully resolved* application ID including the build-type suffix. Located by glob and matched on `variantName`, so it depends on neither Gradle formatting nor AGP's intermediates layout.

Resolution order, first source wins:
1. Explicit `package_name` in the variant's Config.json entry — escape hatch, no inference
2. `output-metadata.json` matched on `variantName`
3. Existing source scraping — kept as last resort, so projects that don't build APKs are unaffected

The `.alpha`/`.beta` suffix is appended **only** for source 3 (which reads pre-suffix values); sources 1 and 2 already include it.

### Verified against the real CorporateBenefits repo
Helper exercised with stubbed `UI`/`smf_config_get` in the CB working directory:

| variant | resolved |
|---|---|
| `pl_live` | `pl.corporatebenefits.app` ← was wrongly `de.corporatebenefits.app` |
| `pl_alpha` | `pl.corporatebenefits.app.alpha` (suffix correct, not doubled) |
| `tr_alpha` | `tr.corporatebenefits.app.alpha` |
| unknown variant | `nil` → falls through to source 3 |

`ruby -c setup/android_setup.rb`: Syntax OK.

### Note on scope
Artifact introspection via `aapt2`/`bundletool` was considered and deliberately left out: it adds SDK-tool discovery as a new failure mode in shared code, and only covers "project builds AAB but no APK", which source 1 already solves explicitly. Documented in the code comment.

### Blast radius
Shared CI code — affects every SMF Android project. Behaviour for projects with literal flavor blocks and an `app/` module is unchanged (source 3 still applies). **Please review; I am not self-merging.**
