### PR TITLE
CBENEFIOS-2704: Search for output-metadata.json from the project root as well

### DIFF
--- a/setup/android_setup.rb
+++ b/setup/android_setup.rb
@@ -912,21 +912,26 @@ def extract_package_from_output_metadata(build_variant)
     return nil
   end
 
-  Dir.glob("**/build/outputs/**/output-metadata.json").each do |path|
-    metadata = begin
-      JSON.parse(File.read(path))
-    rescue StandardError => e
-      UI.message("⚠️ Could not read #{path}: #{e.message}")
-      next
+  # fastlane runs from the `fastlane/` sub directory, so the project root — and with
+  # it every `build/outputs` tree — sits one level up. Search both, the same way the
+  # build.gradle lookup below already carries `../` variants of its paths.
+  ['.', '..'].each do |root|
+    Dir.glob("#{root}/**/build/outputs/**/output-metadata.json").each do |path|
+      metadata = begin
+        JSON.parse(File.read(path))
+      rescue StandardError => e
+        UI.message("⚠️ Could not read #{path}: #{e.message}")
+        next
+      end
+
+      next unless metadata['variantName'].to_s.casecmp(gradle_variant).zero?
+
+      application_id = metadata['applicationId'].to_s
+      next if application_id.empty?
+
+      UI.message("📄 Found applicationId for '#{gradle_variant}' in #{path}")
+      return application_id
     end
-
-    next unless metadata['variantName'].to_s.casecmp(gradle_variant).zero?
-
-    application_id = metadata['applicationId'].to_s
-    next if application_id.empty?
-
-    UI.message("📄 Found applicationId for '#{gradle_variant}' in #{path}")
-    return application_id
   end
 
   UI.message("⚠️ No output-metadata.json with variantName '#{gradle_variant}' found")


### PR DESCRIPTION
## CBENEFIOS-2704 (follow-up) — Search for `output-metadata.json` from the project root as well

### What went wrong
The lookup added in #280 works, but it globbed **relative to the working directory**. fastlane runs from the `fastlane/` sub directory, so `build/outputs` sits one level up and the glob never matched. On CI:

```
🔍 Current directory: .../ate-Benefits-MP_Android_master_2@2/fastlane
⚠️ No output-metadata.json with variantName 'polandRelease' found
⚠️ No AndroidManifest.xml found or package attribute missing
📄 Reading package from build.gradle: ../androidApp/build.gradle.kts
⚠️ No applicationId found for flavor 'poland'
✅ Found default package in build.gradle: de.corporatebenefits.app     ← wrong, as before
```

It fell through to the old source scraping, so the PL Live upload failed with `APK has the wrong package name` exactly as before. My local verification ran from the repo root, which is why it passed there — the existing `build.gradle` lookup in the same file already carries `../` variants of its paths, and I did not mirror that.

### Fix
Search `.` **and** `..`.

### Verified against the CorporateBenefits repo from both working directories

| CWD | `pl_live` resolves to |
|---|---|
| `fastlane/` (as on CI) | **`pl.corporatebenefits.app`** ✓ |
| repo root | `pl.corporatebenefits.app` ✓ |

`pl_alpha` → `pl.corporatebenefits.app.alpha` (suffix correct, not doubled); unknown variant → `nil`, falls through to the legacy sources. `ruby -c`: Syntax OK. Lookup takes well under a second.

Behaviour without this fix was never worse than before #280 — the fallback kept working — but the intended resolution never engaged.
