### PR TITLE
CBENEFIOS-2719: Stop reporting a configured-off state as a build error

### DIFF
--- a/commons/smf_upload_to_firebase/smf_upload_to_firebase.rb
+++ b/commons/smf_upload_to_firebase/smf_upload_to_firebase.rb
@@ -106,7 +106,9 @@ def _smf_get_release_notes_for_firebase(build_variant)
     UI.message("✅ AI release notes ENABLED")
     UI.message("   Provider: #{config[:provider]}")
     UI.message("   Model: #{config[:model]}")
-    UI.message("   API Key Env: #{config[:api_key_env]}")
+    # No API-key line: since the migration to afmcli (CBENEFIOS-2504) generation runs
+    # on-device and api_key_env is a placeholder. Printing it invites the reader to
+    # hunt for a credential that no longer exists in this path.
     UI.message("   Alpha Mode: #{config[:alpha_mode]}")
     UI.message("   Beta Mode: #{config[:beta_mode]}")
 
@@ -170,8 +172,10 @@ def _smf_get_release_notes_for_firebase(build_variant)
       UI.message("ℹ️ No ticket tags found, using standard changelog")
     end
   else
-    UI.message("❌ AI release notes DISABLED")
-    UI.message("   Check Config.json 'ai_release_notes.enabled' and API key environment variable")
+    # Informational, not an error: the standard changelog is a supported configuration,
+    # not a degraded fallback. A ❌ here made green builds look like they had failed a
+    # step, and the old API-key hint was stale after the afmcli migration.
+    UI.message("ℹ️ AI release notes disabled by configuration (ai_release_notes.enabled = false)")
   end
 
   # Fallback to standard changelog


### PR DESCRIPTION
Log output only. No behaviour change.

## Problem

Every Firebase build with `ai_release_notes.enabled = false` prints:

```
❌ AI release notes DISABLED
   Check Config.json 'ai_release_notes.enabled' and API key environment variable
```

Both lines mislead, and they cost real investigation time twice:

- The **❌** marks an intentional configuration as a failure. CorporateBenefits deliberately switched the feature off in CBENEFIOS-2509 ("aggregated changelog wins over LLM polishing"), so a fully green build looks like it lost a step.
- The **API-key hint is stale**. Since the migration to afmcli (CBENEFIOS-2504) generation runs on-device; `smf_ai_release_notes.rb` hardcodes `api_key_env: 'AFMCLI_NO_KEY_NEEDED'` and notes that provider / api_key_env / model are no longer used. There is no credential to check — but the message tells you to go look for one.

## Change

```diff
-    UI.message("❌ AI release notes DISABLED")
-    UI.message("   Check Config.json 'ai_release_notes.enabled' and API key environment variable")
+    UI.message("ℹ️ AI release notes disabled by configuration (ai_release_notes.enabled = false)")
```

This now matches the siblings in the same method, which already get the severity right — `⚠️` for a failed generation (`:169`), `ℹ️` for "no ticket tags found" (`:172`).

Also drops the `API Key Env:` line from the *enabled* branch (`:109`) for the same reason. It is unreachable while the feature is off, but would repeat the confusion the moment anyone turns it back on.

## Explicitly not in scope

Whether AI release notes should be re-enabled is a separate product decision — CBENEFIOS-2509 closed with the opposite conclusion. This PR only makes the log honest about the current state; `enabled` stays untouched.

## Verification

- `ruby -c` on the changed file: **Syntax OK**.
- No `.rubocop.yml` in this repo, so no lint gate to run.
- Grep confirms no remaining `API Key` output in the file; the only surviving `api_key` occurrence is the explanatory comment.
- The gate in `smf_ai_release_notes_enabled?` and the `smf_read_changelog` fallback are untouched, so release-note content is byte-identical.

The changed lines only execute inside a real Firebase build, so the end-to-end check is the console output of the next `de_alpha` build after this merges.

Shared CI infrastructure — please review before merging; I am deliberately not self-merging.